### PR TITLE
Fix gcc11 warning

### DIFF
--- a/Include/Rocket/Core/BaseXMLParser.h
+++ b/Include/Rocket/Core/BaseXMLParser.h
@@ -86,7 +86,7 @@ class ROCKETCORE_API BaseXMLParser
 		// Reads from the stream until a complete word is found.
 		// @param[out] word Word thats been found
 		// @param[in] terminators List of characters that terminate the search
-		bool FindWord(String& word, const char* terminators = NULL);
+		bool FindWord(String& find_word, const char* terminators = NULL);
 		// Reads from the stream until the given character set is found. All
 		// intervening characters will be returned in data.
 		bool FindString(const unsigned char* string, String& data);

--- a/Source/Core/BaseXMLParser.cpp
+++ b/Source/Core/BaseXMLParser.cpp
@@ -353,7 +353,7 @@ bool BaseXMLParser::ReadCDATA(const char* terminator)
 }
 
 // Reads from the stream until a complete word is found.
-bool BaseXMLParser::FindWord(String& word, const char* terminators)
+bool BaseXMLParser::FindWord(String& find_word, const char* terminators)
 {
 	for (;;)
 	{
@@ -366,7 +366,7 @@ bool BaseXMLParser::FindWord(String& word, const char* terminators)
 		// Ignore white space
 		if (StringUtilities::IsWhitespace(*read))
 		{
-			if (word.Empty())
+			if (find_word.Empty())
 			{
 				read++;
 				continue;
@@ -378,10 +378,10 @@ bool BaseXMLParser::FindWord(String& word, const char* terminators)
 		// Check for termination condition
 		if (terminators && strchr(terminators, *read))
 		{
-			return !word.Empty();
+			return !find_word.Empty();
 		}
 
-		word += *read;
+		find_word += *read;
 		read++;
 	}
 }


### PR DESCRIPTION
GCC 11 complains (-Wshadow) about a function parameter declaration shadowing a typedef, so I'd like to rename the parameter.